### PR TITLE
Fix npm package installation: pre-compile Svelte components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # output
 /lib
+/dist-app
 
 # Logs
 logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presentomatic",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presentomatic",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,27 @@
 {
   "name": "presentomatic",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "description": "Simple presentations using markdown",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node presentomatic.js serve example-presentation",
+    "start": "PRESENTOMATIC_DEV=true node presentomatic.js serve example-presentation",
+    "start:prod": "node presentomatic.js serve example-presentation",
     "build": "node presentomatic.js build example-presentation",
-    "pdf": "node presentomatic.js pdf example-presentation"
+    "pdf": "node presentomatic.js pdf example-presentation",
+    "build:app": "vite build",
+    "prepack": "npm run build:app"
   },
   "bin": {
     "presentomatic": "presentomatic.js"
   },
   "type": "module",
+  "files": [
+    "dist-app/",
+    "presentomatic.js",
+    "svelte.config.js",
+    "LICENSE",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tran-engineering/presentomatic.git"

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import svelteConfig from './svelte.config.js';
+
+export default defineConfig({
+  plugins: [svelte(svelteConfig)],
+  build: {
+    outDir: 'dist-app',
+    rollupOptions: {
+      output: {
+        assetFileNames: 'assets/[name].[hash][extname]',
+        chunkFileNames: 'assets/[name].[hash].js',
+        entryFileNames: 'assets/[name].[hash].js',
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Problem
When installing presentomatic from npm tarball, CSS fails to load with errors:
```
[vite-plugin-svelte:load] failed to load virtual css module
```

This happens because Vite's Svelte plugin refuses to process .svelte files located in node_modules.

## Solution
Pre-build Svelte components during `npm pack` and serve the built files when installed from npm.

## Changes
- Add `vite.config.js` for building the app
- Add `prepack` script to build before packaging
- Update `presentomatic.js` to detect and use pre-built files
- Add `files` field to only include necessary files in npm package
- Add `PRESENTOMATIC_DEV` environment flag for development mode

## Testing
- Development: `npm start` or `PRESENTOMATIC_DEV=true presentomatic serve`
- Production: `npm run start:prod` (after building)
- Package: `npm pack` creates working tarball with pre-built files

Fixes CSS loading errors when installed via `npm install -g`.